### PR TITLE
Make it actually install legacy fabric

### DIFF
--- a/src/main/java/net/fabricmc/installer/Handler.java
+++ b/src/main/java/net/fabricmc/installer/Handler.java
@@ -139,7 +139,7 @@ public abstract class Handler implements InstallerProgress {
 	@Override
 	public void updateProgress(String text) {
 		statusLabel.setText(text);
-		statusLabel.setForeground(Color.BLACK);
+		statusLabel.setForeground(UIManager.getColor("Label.foreground"));
 	}
 
 	private void appendException(StringBuilder errorMessage, String prefix, String name, Throwable e) {
@@ -166,15 +166,15 @@ public abstract class Handler implements InstallerProgress {
 
 		System.err.println(errorMessage);
 
+		statusLabel.setText(e.getLocalizedMessage());
+		statusLabel.setForeground(Color.RED);
+
 		JOptionPane.showMessageDialog(
 				pane,
 				errorMessage,
 				Utils.BUNDLE.getString("prompt.exception.occurrence"),
 				JOptionPane.ERROR_MESSAGE
 		);
-
-		statusLabel.setText(e.getLocalizedMessage());
-		statusLabel.setForeground(Color.RED);
 	}
 
 	protected void addRow(Container parent, Consumer<JPanel> consumer) {

--- a/src/main/java/net/fabricmc/installer/Main.java
+++ b/src/main/java/net/fabricmc/installer/Main.java
@@ -20,8 +20,10 @@ import net.fabricmc.installer.client.ClientHandler;
 import net.fabricmc.installer.server.ServerHandler;
 import net.fabricmc.installer.util.ArgumentParser;
 import net.fabricmc.installer.util.CrashDialog;
+import net.fabricmc.installer.util.HardcodedMetaHandler;
 import net.fabricmc.installer.util.MetaHandler;
 import net.fabricmc.installer.util.Reference;
+import net.fabricmc.installer.util.MetaHandler.GameVersion;
 
 import javax.swing.*;
 import java.awt.*;
@@ -70,8 +72,8 @@ public class Main {
 		argumentParser.ifPresent("mavenurl", s -> Reference.mavenServerUrl = s);
 		final String metaUrl = argumentParser.getOrDefault("metaurl", () -> "https://meta.fabricmc.net/");
 
-		GAME_VERSION_META = new MetaHandler(metaUrl + "v2/versions/game");
-		LOADER_META = new MetaHandler(metaUrl + "v2/versions/loader");
+		GAME_VERSION_META = new HardcodedMetaHandler().addVersion("b1.7.3", true);
+		LOADER_META = new HardcodedMetaHandler().addVersion("392aab7", true);
 
 		//Default to the help command in a headless environment
 		if(GraphicsEnvironment.isHeadless() && command == null){

--- a/src/main/java/net/fabricmc/installer/client/ClientInstaller.java
+++ b/src/main/java/net/fabricmc/installer/client/ClientInstaller.java
@@ -33,7 +33,7 @@ public class ClientInstaller {
 		launchJson.inheritsFrom = gameVersion;
 
 		//Adds loader and the mappings
-		launchJson.libraries.add(new MinecraftLaunchJson.Library(Reference.PACKAGE.replaceAll("/", ".") + ":" + Reference.MAPPINGS_NAME + ":" + gameVersion, Reference.mavenServerUrl));
+		launchJson.libraries.add(new MinecraftLaunchJson.Library("com.github.minecraft-cursed-legacy:Plasma:build.9", Reference.mavenServerUrl));
 		launchJson.libraries.add(new MinecraftLaunchJson.Library(Reference.PACKAGE.replaceAll("/", ".") + ":" + Reference.LOADER_NAME + ":" + loaderVersion, Reference.mavenServerUrl));
 
 		File versionsDir = new File(mcDir, "versions");

--- a/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
+++ b/src/main/java/net/fabricmc/installer/server/ServerInstaller.java
@@ -61,7 +61,7 @@ public class ServerInstaller {
 
 		//We add fabric-loader as a lib so it can be downloaded and loaded in the same way as the other libs
 		meta.libraries.add(new MinecraftLaunchJson.Library("net.fabricmc:fabric-loader:" + loaderVersion, Reference.mavenServerUrl));
-		meta.libraries.add(new MinecraftLaunchJson.Library(Reference.PACKAGE.replaceAll("/", ".") + ":" + Reference.MAPPINGS_NAME + ":" + gameVersion, Reference.mavenServerUrl));
+		meta.libraries.add(new MinecraftLaunchJson.Library("com.github.minecraft-cursed-legacy:Plasma:build.9", Reference.mavenServerUrl));
 
 		List<File> libraryFiles = new ArrayList<>();
 

--- a/src/main/java/net/fabricmc/installer/util/HardcodedMetaHandler.java
+++ b/src/main/java/net/fabricmc/installer/util/HardcodedMetaHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.installer.util;
 
 import java.util.ArrayList;

--- a/src/main/java/net/fabricmc/installer/util/HardcodedMetaHandler.java
+++ b/src/main/java/net/fabricmc/installer/util/HardcodedMetaHandler.java
@@ -1,0 +1,31 @@
+package net.fabricmc.installer.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class HardcodedMetaHandler extends MetaHandler {
+
+	private final List<GameVersion> versions = new ArrayList<>();
+	
+	public HardcodedMetaHandler() {
+		super(null);
+	}
+	
+	public List<GameVersion> getVersions() {
+		return Collections.unmodifiableList(versions);
+	}
+	
+	public HardcodedMetaHandler addVersion(String version, boolean stable) {
+		versions.add(new GameVersion(version, stable));
+		return this;
+	}
+	
+	public void load() {
+		complete(versions);
+	}
+	
+	public GameVersion getLatestVersion(boolean snapshot){
+		return versions.get(0); // cursed legacy doesn't exactly need snapshot logic.
+	}
+}

--- a/src/main/java/net/fabricmc/installer/util/MetaHandler.java
+++ b/src/main/java/net/fabricmc/installer/util/MetaHandler.java
@@ -66,6 +66,12 @@ public class MetaHandler extends CompletableHandler<List<MetaHandler.GameVersion
 	public static class GameVersion {
 		String version;
 		boolean stable;
+		
+		GameVersion() { }
+		GameVersion(String version, boolean stable) {
+			this.version = version;
+			this.stable = stable;
+		}
 
 		public String getVersion() {
 			return version;

--- a/src/main/java/net/fabricmc/installer/util/Reference.java
+++ b/src/main/java/net/fabricmc/installer/util/Reference.java
@@ -17,9 +17,9 @@
 package net.fabricmc.installer.util;
 
 public class Reference {
-	public static final String PACKAGE = "net/fabricmc";
-	public static final String LOADER_NAME = "fabric-loader";
-	public static final String MAPPINGS_NAME = "intermediary";
+	public static final String PACKAGE = "com/github/minecraft-cursed-legacy";
+	public static final String LOADER_NAME = "cursed-fabric-loader";
+	public static final String MAPPINGS_NAME = "Plasma";
 
-	public static String mavenServerUrl = "https://maven.fabricmc.net/";
+	public static String mavenServerUrl = "https://jitpack.io/";
 }

--- a/src/main/java/net/fabricmc/installer/util/Utils.java
+++ b/src/main/java/net/fabricmc/installer/util/Utils.java
@@ -110,9 +110,7 @@ public class Utils {
 	}
 
 	public static MinecraftLaunchJson getLaunchMeta(String loaderVersion) throws IOException {
-		String url = String.format("%s/%s/%s/%s/%3$s-%4$s.json", Reference.mavenServerUrl, Reference.PACKAGE, Reference.LOADER_NAME, loaderVersion);
-		String fabricInstallMeta = Utils.readTextFile(new URL(url));
-		JsonObject installMeta = Utils.GSON.fromJson(fabricInstallMeta, JsonObject.class);
+		JsonObject installMeta = Utils.GSON.fromJson(new InputStreamReader(Utils.class.getClassLoader().getResourceAsStream("launchmeta.json")), JsonObject.class);
 		return new MinecraftLaunchJson(installMeta);
 	}
 

--- a/src/main/resources/launchmeta.json
+++ b/src/main/resources/launchmeta.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "libraries": {
+    "client": [
+
+    ],
+    "common": [
+      {
+        "name": "net.fabricmc:tiny-mappings-parser:0.2.2.14",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "net.fabricmc:sponge-mixin:0.8+build.18",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "net.fabricmc:tiny-remapper:0.3.0.70",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "net.fabricmc:fabric-loader-sat4j:2.3.5.4",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "com.google.jimfs:jimfs:1.1",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "org.ow2.asm:asm:8.0",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "org.ow2.asm:asm-analysis:8.0",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "org.ow2.asm:asm-commons:8.0",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "org.ow2.asm:asm-tree:8.0",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "org.ow2.asm:asm-util:8.0",
+        "url": "https://maven.fabricmc.net/"
+      },
+      {
+        "name": "org.apache.logging.log4j:log4j-api:2.8.1",
+        "url": "https://libraries.minecraft.net/"
+      },
+      {
+        "name": "org.apache.logging.log4j:log4j-core:2.8.1",
+        "url": "https://libraries.minecraft.net/"
+      },
+      {
+        "name": "com.google.code.gson:gson:2.8.6",
+        "url": "https://repo1.maven.org/maven2/"
+      }
+    ],
+    "server": [
+      {
+        "_comment": "jimfs in fabric-server-launch requires guava on the system classloader",
+        "name": "com.google.guava:guava:21.0",
+        "url": "https://maven.fabricmc.net/"
+      }
+    ]
+  },
+  "mainClass": {
+    "client": "net.fabricmc.loader.launch.knot.KnotClient",
+    "server": "net.fabricmc.loader.launch.knot.KnotServer"
+  }
+}


### PR DESCRIPTION
Yeah. In theme with the rest of cursed legacy, this also significantly increases the cursedness of this installer. Cursed things of note:
*The created launcher JSON fetches Plasma and cursed loader from JitPack.
*Cursed loader is built against GSON 2.8.6, and therefore not compatible with GSON 2.8.0, the newest version on Mojang's maven. Therefore, the launcher JSON fetches it from Maven Central. (This is likely a cursed loader bug.)
*Everything is hardcoded now, since we don't have a file host.